### PR TITLE
FIX setSuccessMessage is no longer used for BetterButtonCustomAction

### DIFF
--- a/src/Model/ContentNotifierQueue.php
+++ b/src/Model/ContentNotifierQueue.php
@@ -97,13 +97,11 @@ class ContentNotifierQueue extends DataObject
             $fields->push(
                 BetterButtonCustomAction::create('deny', 'Deny')
                     ->setRedirectType(BetterButtonCustomAction::REFRESH)
-                    ->setSuccessMessage('Denied for publication')
             );
         } else {
             $fields->push(
                 BetterButtonCustomAction::create('approve', 'Approve')
                     ->setRedirectType(BetterButtonCustomAction::REFRESH)
-                    ->setSuccessMessage('Approved for publication')
             );
         }
 
@@ -128,6 +126,8 @@ class ContentNotifierQueue extends DataObject
     {
         if ($this->getRecord()) {
             $this->getRecord()->approve();
+
+            return 'Approved for publication';
         }
     }
 
@@ -135,6 +135,8 @@ class ContentNotifierQueue extends DataObject
     {
         if ($this->getRecord()) {
             $this->getRecord()->deny();
+
+            return 'Denied for publication';
         }
     }
 


### PR DESCRIPTION
As part of [this issue for unclecheese/silverstripe-gridfield-betterbuttons](https://github.com/unclecheese/silverstripe-gridfield-betterbuttons/issues/102) the `setSuccessMessage ` is no longer used; the success message is now set by the action's return value.  

As it stands leaving this function call in results in `Exception: Object->__call(): the method 'setsuccessmessage' does not exist on 'BetterButtonCustomAction', or the method is not public.`

This change will also need to be backported to the 1.0 branch as it's affecting the SS3 version too.